### PR TITLE
Rename 'distance' to 'similarity'

### DIFF
--- a/src/pages/neighbourhood.js
+++ b/src/pages/neighbourhood.js
@@ -70,7 +70,7 @@ function WordNumberPage() {
             <thead>
               <tr>
                 <th>Word</th>
-                <th>Distance</th>
+                <th>Similarity</th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Rename the "distance" word in the neighbourhood analogy to "similarity" as this is a more accurate name for this value.